### PR TITLE
On PHP >=  8.2 allow comment to have renderedBody property correctly set upon deserialization.

### DIFF
--- a/src/Issue/Comment.php
+++ b/src/Issue/Comment.php
@@ -18,6 +18,9 @@ class Comment implements \JsonSerializable
     /** @var string */
     public $body;
 
+    /** @var string */
+    public $renderedBody;
+
     /** @var \JiraRestApi\Issue\Reporter */
     public $updateAuthor;
 


### PR DESCRIPTION
On PHP >=  8.2 allow comment to have renderedBody property correctly set upon deserialization.